### PR TITLE
Minor Edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Pull requests and Issues are very welcomed and encouraged, but please don't get 
  
 - How do you handle change requests?
 
-- Do you have a SLA (Service Layer Agreement)?
+- Do you have an SLA (Service Level Agreement)?
   - Do you guarantee any of the following? If so, how long?
     - Turn Around Time TAT?  
     - Average Speed to Answer (ASA)


### PR DESCRIPTION
Asking about a Service Layer Agreement could actually make you look as though you don't know what you're talking about.

Phonetically the capital letter S when pronounced is like "ess" because it sounds like a vowel sound 'e' it's considered a more correct form to use "an" - this may be specific to the UK, I'm not sure what the American standard is here.